### PR TITLE
Get-RegistryAutoLogon: print passwords when found

### DIFF
--- a/Privesc/PowerUp.ps1
+++ b/Privesc/PowerUp.ps1
@@ -3526,26 +3526,23 @@ https://github.com/rapid7/metasploit-framework/blob/master/modules/post/windows/
     $AutoAdminLogon = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name AutoAdminLogon -ErrorAction SilentlyContinue)
     Write-Verbose "AutoAdminLogon key: $($AutoAdminLogon.AutoAdminLogon)"
 
-    if ($AutoAdminLogon -and ($AutoAdminLogon.AutoAdminLogon -ne 0)) {
+    $DefaultDomainName = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name DefaultDomainName -ErrorAction SilentlyContinue).DefaultDomainName
+    $DefaultUserName = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name DefaultUserName -ErrorAction SilentlyContinue).DefaultUserName
+    $DefaultPassword = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name DefaultPassword -ErrorAction SilentlyContinue).DefaultPassword
+    $AltDefaultDomainName = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name AltDefaultDomainName -ErrorAction SilentlyContinue).AltDefaultDomainName
+    $AltDefaultUserName = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name AltDefaultUserName -ErrorAction SilentlyContinue).AltDefaultUserName
+    $AltDefaultPassword = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name AltDefaultPassword -ErrorAction SilentlyContinue).AltDefaultPassword
 
-        $DefaultDomainName = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name DefaultDomainName -ErrorAction SilentlyContinue).DefaultDomainName
-        $DefaultUserName = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name DefaultUserName -ErrorAction SilentlyContinue).DefaultUserName
-        $DefaultPassword = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name DefaultPassword -ErrorAction SilentlyContinue).DefaultPassword
-        $AltDefaultDomainName = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name AltDefaultDomainName -ErrorAction SilentlyContinue).AltDefaultDomainName
-        $AltDefaultUserName = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name AltDefaultUserName -ErrorAction SilentlyContinue).AltDefaultUserName
-        $AltDefaultPassword = $(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name AltDefaultPassword -ErrorAction SilentlyContinue).AltDefaultPassword
-
-        if ($DefaultUserName -or $AltDefaultUserName) {
-            $Out = New-Object PSObject
-            $Out | Add-Member Noteproperty 'DefaultDomainName' $DefaultDomainName
-            $Out | Add-Member Noteproperty 'DefaultUserName' $DefaultUserName
-            $Out | Add-Member Noteproperty 'DefaultPassword' $DefaultPassword
-            $Out | Add-Member Noteproperty 'AltDefaultDomainName' $AltDefaultDomainName
-            $Out | Add-Member Noteproperty 'AltDefaultUserName' $AltDefaultUserName
-            $Out | Add-Member Noteproperty 'AltDefaultPassword' $AltDefaultPassword
-            $Out.PSObject.TypeNames.Insert(0, 'PowerUp.RegistryAutoLogon')
-            $Out
-        }
+    if ($DefaultUserName -or $AltDefaultUserName) {
+        $Out = New-Object PSObject
+        $Out | Add-Member Noteproperty 'DefaultDomainName' $DefaultDomainName
+        $Out | Add-Member Noteproperty 'DefaultUserName' $DefaultUserName
+        $Out | Add-Member Noteproperty 'DefaultPassword' $DefaultPassword
+        $Out | Add-Member Noteproperty 'AltDefaultDomainName' $AltDefaultDomainName
+        $Out | Add-Member Noteproperty 'AltDefaultUserName' $AltDefaultUserName
+        $Out | Add-Member Noteproperty 'AltDefaultPassword' $AltDefaultPassword
+        $Out.PSObject.TypeNames.Insert(0, 'PowerUp.RegistryAutoLogon')
+        $Out
     }
 }
 


### PR DESCRIPTION
To be honest I don't know how often that occurs in practice. But on a training machine I encountered the case that the registry key `AutoAdminLogon` was not present, hence `Get-RegistryAutoLogon` aborted early. In fact, `DefaultUserName` and `DefaultPassword` were present but were not retrieved by PowerUp.

This PR changes the semantics of `Get-RegistryAutoLogon` so that retrieved credentials are printed regardless the actual state of `AutoAdminLogon`. (Diff looks horrible but actually only the if got removed.)

Reasonable?